### PR TITLE
Preserve spaces in the output window

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -240,7 +240,7 @@ body {
     display: inline-block;
     word-break: break-all;
     margin-block: 0;
-
+    white-space: pre;
 }
 
 #file_browser {


### PR DESCRIPTION
Prevents browser from trimming whitespaces in the output window